### PR TITLE
Fix link to docs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -71,7 +71,7 @@
         <a href="https://boa-dev.github.io/boa/dev/bench/">Benchmarks</a> |
         <a href="https://boa-dev.github.io/boa/test262/">Conformance</a> |
         <a href="https://boa-dev.github.io/boa/playground">Playground</a> |
-        <a href="https://boa-dev.github.io/boa/doc/boa/index.html">Docs</a>
+        <a href="https://boa-dev.github.io/boa/doc">Docs</a>
       </div>
     </nav>
     <!-- <label class="site-switch-theme">


### PR DESCRIPTION
The old link was still pointing directly to the `Boa` crate.