### PR TITLE
New website links

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,9 +1,9 @@
 {
   "baseurl": "/",
-  "url": "https://boa-dev.github.io",
+  "url": "https://boajs.dev",
   "logo": "/images/logo.png",
   "title": "Boa",
-  "description": "The blog and website for Boa",
+  "description": "The Boa JavaScript engine",
   "github_username": "boa-dev",
   "twitter_username": "boa_engine"
 }

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,18 +43,17 @@
     }
   </script>
   <div class="wrapper">
-    <a class="site-title" href="{{ site.baseurl }}"
-      ><img id="site-logo" src="{{ site.logo }}" /> {{ site.title }}</a
-    >
+    <a class="site-title" href="{{ site.baseurl }}">
+      <img id="site-logo" src="{{ site.logo }}" /> {{ site.title }}</a>
 
     <nav class="site-nav">
       <div class="trigger">
         <a href="/about">About</a> |
         <a href="https://github.com/boa-dev/boa">Github</a> |
-        <a href="https://boa-dev.github.io/boa/dev/bench/">Benchmarks</a> |
-        <a href="https://boa-dev.github.io/boa/test262/">Conformance</a> |
-        <a href="https://boa-dev.github.io/boa/playground">Playground</a> |
-        <a href="https://boa-dev.github.io/boa/doc">Docs</a>
+        <a href="/boa/dev/bench/">Benchmarks</a> |
+        <a href="/boa/test262/">Conformance</a> |
+        <a href="/boa/playground">Playground</a> |
+        <a href="https://docs.rs/boa_engine">Docs</a>
       </div>
     </nav>
   </div>

--- a/about.html
+++ b/about.html
@@ -4,10 +4,12 @@ layout: default
 
 <div class="home">
 <H1>About</H1>
-  <p>
-    Boa is an experimental Javascript lexer, parser and compiler written in Rust. Currently, it has support for some of the language. It can be embedded in Rust projects fairly easily and also used from the command line.  
-Boa also exists to serve as a Rust implementation of the EcmaScript specification, there will be areas where we can utilise Rust and its fantastic ecosystem to make a fast, concurrent and safe engine.
-  </p>
+  <p>Boa is an experimental Javascript lexer, parser and compiler written in Rust.
+    Currently, it has support for some of the language. It can be embedded in Rust
+    projects fairly easily and also used from the command line.  
+    Boa also exists to serve as a Rust implementation of the EcmaScript specification,
+    there will be areas where we can utilise Rust and its fantastic ecosystem to make
+    a fast, concurrent and safe engine.</p>
 
   <p><a href="https://github.com/boa-dev/boa">Boa's Github page</a></p>
 

--- a/index.html
+++ b/index.html
@@ -3,10 +3,13 @@ layout: default
 ---
 
 <div class="home">
-  <p>
-    Boa is an experimental Javascript lexer, parser and compiler written in Rust. Currently, it has support for some of the language. It can be embedded in Rust projects fairly easily and also used from the command line.  
-Boa also exists to serve as a Rust implementation of the EcmaScript specification, there will be areas where we can utilise Rust and its fantastic ecosystem to make a fast, concurrent and safe engine.
-  </p>
+  <p>Boa is an experimental Javascript lexer, parser and compiler written in Rust.
+    Currently, it has support for some of the language. It can be embedded in Rust
+    projects fairly easily and also used from the command line.  
+    Boa also exists to serve as a Rust implementation of the EcmaScript specification,
+    there will be areas where we can utilise Rust and its fantastic ecosystem to make
+    a fast, concurrent and safe engine.</p>
+
   <h1 class="page-heading">Posts</h1>
 
   <ul class="post-list">


### PR DESCRIPTION
 - Changed the base URL to boajs.dev
 - Changed the documentation link to point to the "user" documentation instead of the "developer" documentation
 - A couple of style changes