### PR TITLE
Fixing the CNAME removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
       - run: npm ci
       - name: build
         run: npm run build
+      - name: Add CNAME to site
+        run: echo "boajs.dev" > ./_site/CNAME
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
The website was going down every now and then, so I contacted GitHub support.

After talking with them, they noticed that the CNAME field in the gh-pages branch was being removed by the deployment action. This should fix it.

Example of the commit removing the CNAME file: https://github.com/boa-dev/boa-dev.github.io/commit/f8dcc2a79429bbdb040874627c8ec85eaebdf4ff