### PR TITLE
Update headers `RegExp` and `Atomics/SharedArrayBuffers`

### DIFF
--- a/blog/2024-03-07-boa-release-18.md
+++ b/blog/2024-03-07-boa-release-18.md
@@ -120,7 +120,7 @@ has been made, there is still more work to be completed until it is production r
 If you're interested in learning more or want to contribute to the native Rust implementation of
 Temporal, feel free to check out `temporal_rs`'s [issues](https://github.com/boa-dev/temporal/issues)!
 
-## RegExp
+### RegExp
 
 Over the past 7 months there has been some effort poured into an improved implementation of RegExp.
 This includes:
@@ -146,7 +146,7 @@ The remaining skipped tests are all related to stage 3 proposals.
 
 [`RegExp.prototype.hasIndices`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices
 
-## Shared Array Buffer + Atomics
+### Shared Array Buffer + Atomics
 
 The [SharedArrayBuffer] and [Atomics] builtins have been implemented in this release.
 This means embedders can now orchestrate `Context`s running on separate threads to execute


### PR DESCRIPTION
Nests the `RegExp` and `Shared Array Buffers and Atomics` headers under highlights.