### PR TITLE
use data from data repo

### DIFF
--- a/src/pages/conformance/index.tsx
+++ b/src/pages/conformance/index.tsx
@@ -1,9 +1,9 @@
-import Layout from "@theme/Layout";
-import React from "react";
-import { VersionItem } from "@site/src/components/conformance/types";
-import VersionSelector from "@site/src/components/conformance/VersionSelector";
 import ConformanceBanner from "@site/src/components/conformance/Banner";
 import ResultsDisplay from "@site/src/components/conformance/ResultsDisplay";
+import VersionSelector from "@site/src/components/conformance/VersionSelector";
+import { VersionItem } from "@site/src/components/conformance/types";
+import Layout from "@theme/Layout";
+import React from "react";
 
 import styles from "./styles.module.css";
 
@@ -25,28 +25,28 @@ export default function Conformance() {
 
     const fetchReleases = async () => {
       const response = await fetch(
-        "https://api.github.com/repos/boa-dev/boa/releases",
+        "https://api.github.com/repos/boa-dev/boa/releases"
       );
       const releases = await response.json();
       return releases
         .filter((potentialRelease) =>
-          validateReleaseVersion(potentialRelease.tag_name),
+          validateReleaseVersion(potentialRelease.tag_name)
         )
         .map((release) => {
           return {
             tagName: release.tag_name,
-            fetchUrl: `https://boajs.dev/boa/test262/refs/tags/${release.tag_name}/latest.json`,
+            fetchUrl: `https://raw.githubusercontent.com/boa-dev/data/main/test262/refs/tags/${release.tag_name}/latest.json`,
           };
         });
     };
 
     const mainVersion = {
       tagName: "main",
-      fetchUrl: `https://boajs.dev/boa/test262/refs/heads/main/latest.json`,
+      fetchUrl: `https://raw.githubusercontent.com/boa-dev/data/main/test262/refs/heads/main/latest.json`,
     };
 
     fetchReleases().then((releases) =>
-      setReleaseRecords([mainVersion, ...releases]),
+      setReleaseRecords([mainVersion, ...releases])
     );
   }, []);
 


### PR DESCRIPTION
Use data URLS so that we can move away from having test262 data in the main boa repo
Prettier also ran and formatted some code.

From browsing around it seems to work as normal