### PR TITLE
Remove all references to the development docs

### DIFF
--- a/blog/2023-07-08-boa-release-17.md
+++ b/blog/2023-07-08-boa-release-17.md
@@ -257,7 +257,7 @@ Boa now has internationalization support! Although we are still working on full 
 - [`Intl.Segmenter`][segmenter]
 
 Internationalization data can be pretty expensive at times: the default data included by Boa is 10.6 MB, which is why
-we allow customizing the data provider used by the engine with the [`ContextBuilder::icu_provider`][ctx_provider] hook.
+we allow customizing the data provider used by the engine with the `ContextBuilder::icu_provider` hook.
 For more information on how to generate custom internationalization data, you can check out the
 [**data management tutorial**][data] from [`icu4x`], the internationalization library used in Boa. Shoutout to the
 `icu4x` team, who are the ones that made all of this possible!
@@ -270,8 +270,6 @@ size.
 [list]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
 [locale]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator
 [segmenter]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter
-[provider]: https://boajs.dev/boa/doc/boa_engine/context/enum.BoaProvider.html
-[ctx_provider]: https://boajs.dev/boa/doc/boa_engine/context/struct.ContextBuilder.html#method.icu_provider
 [data]: https://github.com/unicode-org/icu4x/blob/main/docs/tutorials/data_management.md#data-management-in-icu4x
 [`icu4x`]: https://github.com/unicode-org/icu4x
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -64,11 +64,6 @@ Boa has some pre-defined tasks in ".vscode/tasks.json"
 If you don't want to install everything on your machine, you can use the Dockerfile.
 Start VSCode in container mode (you may need the docker container plugin) and use the Dockerfile.
 
-## Documentation
-
-We have specific documentation for development, updated on each commit to the `main` branch, with all the private
-methods visible here: https://boajs.dev/boa/doc/
-
 ## Communication
 
 We have a Discord server, feel free to ask questions [here](https://discord.gg/tUFFk9Y)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -117,12 +117,8 @@ const config: Config = {
               to: "/docs/intro",
             },
             {
-              label: "Release API",
+              label: "API Documentation",
               href: "https://docs.rs/boa_engine/latest",
-            },
-            {
-              label: "Development API",
-              href: "https://boajs.dev/boa/doc/boa_engine/index.html",
             },
           ],
         },

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -30,13 +30,7 @@ function HomepageHeader() {
             className={"button button--secondary " + styles.buttonMargin}
             href="https://docs.rs/boa_engine/latest/boa_engine/"
           >
-            Release Documentation
-          </Link>
-          <Link
-            className={"button button--secondary " + styles.buttonMargin}
-            href="https://boajs.dev/boa/doc/boa_engine/index.html"
-          >
-            Dev Documentation
+            Documentation
           </Link>
         </div>
       </div>


### PR DESCRIPTION
Should allow us to remove the `gh-pages` branch from the boa repo.