### PR TITLE
Filter out empty suite results for version

### DIFF
--- a/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
+++ b/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
@@ -19,7 +19,6 @@ export default function SuiteSelector(props: SelectorProps): JSX.Element {
           return versionStats.total !== 0;
         })
         .map((suite) => {
-          console.log(`${suite.name}:`, suite);
           return (
             <SuiteItem
               key={suite.name}

--- a/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
+++ b/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SuiteResult } from "@site/src/components/conformance/types";
+import { SuiteResult, TestStats } from "@site/src/components/conformance/types";
 
 import styles from "./styles.module.css";
 
@@ -14,7 +14,12 @@ export default function SuiteSelector(props: SelectorProps): JSX.Element {
     <div className={styles.suiteSelector}>
       {props.suites
         .sort((a, b) => a.name.localeCompare(b.name))
+        .filter((suite) => {
+          let versionStats: TestStats = suite.versionedStats[props.esFlag];
+          return versionStats.total !== 0;
+        })
         .map((suite) => {
+          console.log(`${suite.name}:`, suite);
           return (
             <SuiteItem
               key={suite.name}

--- a/src/components/conformance/ResultsDisplay/nav.tsx
+++ b/src/components/conformance/ResultsDisplay/nav.tsx
@@ -13,7 +13,10 @@ type ResultsNavProps = {
 export default function ResultNavigation(props: ResultsNavProps): JSX.Element {
   return (
     <div className={styles.resultsNav}>
-      <EcmaScriptVersionDropdown setEcmaScriptFlag={props.setEcmaScriptFlag} esVersionValue={props.state.ecmaScriptVersion} />
+      <EcmaScriptVersionDropdown
+        setEcmaScriptFlag={props.setEcmaScriptFlag}
+        esVersionValue={props.state.ecmaScriptVersion}
+      />
       <NavBreadCrumbs
         navPath={props.state.testPath}
         sliceNavToIndex={props.sliceNavToIndex}
@@ -79,12 +82,14 @@ type DropDownProps = {
 };
 
 function EcmaScriptVersionDropdown(props: DropDownProps): JSX.Element {
-  const [dropdownValue, setDropdownValue] = React.useState(props.esVersionValue ? props.esVersionValue : "");
+  const [dropdownValue, setDropdownValue] = React.useState(
+    props.esVersionValue ? props.esVersionValue : "",
+  );
 
   // Update the flag when props.esVersionValue is changed
-  React.useEffect(()=>{
-    setDropdownValue(props.esVersionValue)
-  }, [props.esVersionValue])
+  React.useEffect(() => {
+    setDropdownValue(props.esVersionValue);
+  }, [props.esVersionValue]);
 
   const handleVersionSelection = (e) => {
     // Update the display value and set the flag.


### PR DESCRIPTION
Another feature (although this one is more of a bug fix really) from #148. :smile: