### PR TITLE
Add truncation markers and a central `Boa Developers` author

### DIFF
--- a/blog/2020-07-03-boa-release-09/index.md
+++ b/blog/2020-07-03-boa-release-09/index.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Boa v0.9: measureme & optimisations"
-author: Boa Developers
+authors: boa-dev
 tags: [post]
 permalink: 2020/07/03/boa-release-09.html
 ---
@@ -13,6 +13,8 @@ Boa also exists to serve as a Rust implementation of the EcmaScript specificatio
 
 Today we're pleased to announce our latest release, version 0.9.  
 v0.9 is by far the biggest release we've had since Boa began. You can find the full changes from the [changelog](https://github.com/boa-dev/boa/blob/main/CHANGELOG.md#-090-2020-06-25---move-to-organisation-78-faster-execution-time). The milestone behind this version was further optimisation and an increase in new features. We can show you how we can identify areas that can be optimised.
+
+<!--truncate-->
 
 ## Better tooling for profiling
 

--- a/blog/2020-10-02-boa-release-10/index.md
+++ b/blog/2020-10-02-boa-release-10/index.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.10"
-author: Boa Developers
+authors: boa-dev
 permalink: 2020/10/02/boa-release-10.html
 ---
 
@@ -12,6 +12,8 @@ Boa also exists to serve as a Rust implementation of the EcmaScript specificatio
 We have a long way to go, however v0.10 has been the biggest release to date, with 138 issues closed!
 
 We have some highlights, but if you prefer to read the full changelog, you can do that [here](https://github.com/boa-dev/boa/blob/main/CHANGELOG.md)
+
+<!--truncate-->
 
 ## Test262
 

--- a/blog/2021-01-14-boa-release-11/index.mdx
+++ b/blog/2021-01-14-boa-release-11/index.mdx
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.11"
-author: Boa Developers
+authors: boa-dev
 ---
 
 Boa has reached a new release. v0.11, our biggest one yet!
@@ -10,6 +10,8 @@ Boa has reached a new release. v0.11, our biggest one yet!
 Since v0.10 we've closed 77 issues and merged 129 pull requests. The engine has been faster and more compliant to the spec. Below are some of the highlights but please see the [changelog](https://github.com/boa-dev/boa/blob/main/CHANGELOG.md#0110-2021-01-14) for more information.
 
 What is Boa? See the [About](/about) page for more info.
+
+<!--truncate-->
 
 ## Test 262
 

--- a/blog/2021-06-07-boa-release-12.md
+++ b/blog/2021-06-07-boa-release-12.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.12"
-author: Boa Developers
+authors: boa-dev
 ---
 
 Boa v0.12 is here! Boa is a JavaScript parser, compiler and executor written in the Rust programming language. It makes it easy to embed a JS engine in your projects, and you can even use it from webassembly. See the [About](/about) page for more info.
@@ -10,6 +10,8 @@ Boa v0.12 is here! Boa is a JavaScript parser, compiler and executor written in 
 We currently support part of the language. In this release, our conformance has grown to 33.97% of the official ECMAScript Test Suite (Test262). In this release, we have closed 19 issues and merged 69 pull requests. You can check the full list of changes [here](https://github.com/boa-dev/boa/blob/v0.12/CHANGELOG.md).
 
 Let's dive into the most relevant changes of this release.
+
+<!--truncate-->
 
 ## Panic-free
 

--- a/blog/2021-09-30-boa-release-13.md
+++ b/blog/2021-09-30-boa-release-13.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.13"
-author: Boa Developers
+authors: boa-dev
 permalink: 2021/09/30/boa-release-13.html
 ---
 
@@ -11,6 +11,8 @@ Boa v0.13 is here! Boa is a JavaScript engine written in the Rust programming la
 We currently support part of the language. In this release, our conformance has grown to 41.97% of the official ECMAScript Test Suite (Test262). We have closed 40 issues and merged 105 pull requests. You can check the full list of changes [here](https://github.com/boa-dev/boa/blob/v0.13/CHANGELOG.md).
 
 This release brings some new features, such as support for calling Rust closures from JavaScript to improve better interopability between JS and Rust.
+
+<!--truncate-->
 
 ## ECMAScript language features
 

--- a/blog/2022-03-15-boa-release-14.md
+++ b/blog/2022-03-15-boa-release-14.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.14"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -16,6 +16,8 @@ in the official ECMAScript Test Suite (Test262). The engine now passes 43,986 te
 (32.5% increase), and we have closed 40 issues and merged 137 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.14/CHANGELOG.md), and the full information on conformance
 [here](https://boa-dev.github.io/boa/test262/).
+
+<!--truncate-->
 
 ## Boa has moved
 

--- a/blog/2022-06-10-boa-release-15.md
+++ b/blog/2022-06-10-boa-release-15.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.15"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -16,6 +16,8 @@ in the official ECMAScript Test Suite (Test262). The engine now passes 56,372 te
 (28.1% increase), and we have closed 18 issues and merged 58 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.15/CHANGELOG.md), and the full information on conformance
 [here](https://boa-dev.github.io/boa/test262/).
+
+<!--truncate-->
 
 ## New ECMAScript features
 

--- a/blog/2022-09-25-boa-release-16.md
+++ b/blog/2022-09-25-boa-release-16.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.16"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -16,6 +16,8 @@ in the official ECMAScript Test Suite (Test262). The engine now passes 68,612 te
 (21.7% increase), and we have closed 9 issues and merged 59 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.16/CHANGELOG.md), and the full information on conformance
 [here](https://boa-dev.github.io/boa/test262/).
+
+<!--truncate-->
 
 ## New ECMAScript features
 

--- a/blog/2022-10-24-boa-usage.md
+++ b/blog/2022-10-24-boa-usage.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Adding a JavaScript interpreter to your Rust project"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Introduction
@@ -31,6 +31,8 @@ _Note: You can see more examples of integrating Boa in [our repository][examples
 [issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22%2CHacktoberfest%2CE-Easy%2C%22good+first+issue%22+no%3Aassignee
 [opencollective]: https://opencollective.com/boa
 [examples-repo]: https://github.com/boa-dev/boa/tree/main/boa_examples
+
+<!--truncate-->
 
 ## Starting from scratch
 

--- a/blog/2023-07-08-boa-release-17.md
+++ b/blog/2023-07-08-boa-release-17.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.17"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -31,6 +31,8 @@ Furthermore, we now have a new domain for Boa, [boajs.dev][boajs].
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [boajs]: https://boajs.dev
+
+<!--truncate-->
 
 ## Highlights
 

--- a/blog/2024-03-07-boa-release-18.md
+++ b/blog/2024-03-07-boa-release-18.md
@@ -2,7 +2,7 @@
 layout: post
 tags: [post]
 title: "Boa release v0.18"
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -42,6 +42,8 @@ some code instead.
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+
+<!--truncate-->
 
 ## Highlights
 

--- a/blog/2024-07-09-boa-release-19.md
+++ b/blog/2024-07-09-boa-release-19.md
@@ -3,7 +3,7 @@ layout: post
 tags: [post]
 title: "Boa release v0.19"
 description: "More progress on Temporal, new benchmarks, migration to Matrix, and more..."
-author: Boa Developers
+authors: boa-dev
 ---
 
 ## Summary
@@ -20,6 +20,8 @@ Overall, Boa's conformance in real terms has improved by ~6%.
 
 You can check the full list of changes [here][changelog], and the full information on conformance
 [here][conformance].
+
+<!--truncate-->
 
 ## Highlights
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,17 +1,3 @@
-endi:
-  name: Endilie Yacop Sucipto
-  title: Maintainer of Docusaurus
-  url: https://github.com/endiliey
-  image_url: https://github.com/endiliey.png
-
-yangshun:
-  name: Yangshun Tay
-  title: Front End Engineer @ Facebook
-  url: https://github.com/yangshun
-  image_url: https://github.com/yangshun.png
-
-slorber:
-  name: Sébastien Lorber
-  title: Docusaurus maintainer
-  url: https://sebastienlorber.com
-  image_url: https://github.com/slorber.png
+boa-dev:
+  name: Boa Developers
+  url: https://github.com/boa-dev


### PR DESCRIPTION
This PR fixes some docusaurus warnings while building the pages.

* Add truncation markers to all blog pages so that only that start of the blogs is shown on the blog list.
* Add and reference a central author