### PR TITLE
Update links & conformance banner

### DIFF
--- a/blog/2021-01-14-boa-release-11/index.mdx
+++ b/blog/2021-01-14-boa-release-11/index.mdx
@@ -33,7 +33,7 @@ import conformance_dark from "./conformance_dark.png";
 
 Previously many tests failed to run as the test-runner was still being worked on. Those issues have been fixed and our tests jumped from 38k to 78K which is why the graph flips up above. Boa should never panic, however we've had many tests reveal areas where panics happen, this has helped us identify and apply correct fixes, to the point where our panics have gone from hundreds to under 50 (the graph above shows the dark red diminishing).
 
-For live tracking of conformance tests you can check [here](https://boa-dev.github.io/boa/test262/). Below is a snapshot of the previous version and today.
+For live tracking of conformance tests you can check [here](/conformance). Below is a snapshot of the previous version and today.
 
 <div
   className="row"

--- a/blog/2021-09-30-boa-release-13.md
+++ b/blog/2021-09-30-boa-release-13.md
@@ -79,7 +79,7 @@ Test262 is the implementation conformance test suite maintained by TC39. It's us
 
 Since v0.12 we have managed to pass 6391 more tests and are 7% more conformant. This has been great progress by all involved and we hope this continues to improve. Most of these new passes have come from refactors across the codebase which have had little impact on performance, in fact, v0.13 is much faster than v0.12.
 
-You can track Boa's conformance to the specification [here](/conformance#)
+You can track Boa's conformance to the specification [here](/conformance)
 
 ## Keeping up with Rust
 

--- a/blog/2021-09-30-boa-release-13.md
+++ b/blog/2021-09-30-boa-release-13.md
@@ -79,7 +79,7 @@ Test262 is the implementation conformance test suite maintained by TC39. It's us
 
 Since v0.12 we have managed to pass 6391 more tests and are 7% more conformant. This has been great progress by all involved and we hope this continues to improve. Most of these new passes have come from refactors across the codebase which have had little impact on performance, in fact, v0.13 is much faster than v0.12.
 
-You can track Boa's conformance to the specification [here](https://boa-dev.github.io/boa/test262/#)
+You can track Boa's conformance to the specification [here](/conformance#)
 
 ## Keeping up with Rust
 

--- a/blog/2022-03-15-boa-release-14.md
+++ b/blog/2022-03-15-boa-release-14.md
@@ -15,7 +15,7 @@ Boa currently supports part of the JavaScript language. In this release, our con
 in the official ECMAScript Test Suite (Test262). The engine now passes 43,986 tests, coming from 33,192 in Boa 0.13
 (32.5% increase), and we have closed 40 issues and merged 137 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.14/CHANGELOG.md), and the full information on conformance
-[here](https://boa-dev.github.io/boa/test262/).
+[here](/conformance).
 
 <!--truncate-->
 

--- a/blog/2022-06-10-boa-release-15.md
+++ b/blog/2022-06-10-boa-release-15.md
@@ -15,7 +15,7 @@ Boa currently supports part of the JavaScript language. In this release, our con
 in the official ECMAScript Test Suite (Test262). The engine now passes 56,372 tests, coming from 43,986 in Boa 0.14
 (28.1% increase), and we have closed 18 issues and merged 58 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.15/CHANGELOG.md), and the full information on conformance
-[here](https://boa-dev.github.io/boa/test262/).
+[here](/conformance).
 
 <!--truncate-->
 

--- a/blog/2022-09-25-boa-release-16.md
+++ b/blog/2022-09-25-boa-release-16.md
@@ -15,7 +15,7 @@ Boa currently supports part of the JavaScript language. In this release, our con
 in the official ECMAScript Test Suite (Test262). The engine now passes 68,612 tests, coming from 56,372 in Boa 0.15
 (21.7% increase), and we have closed 9 issues and merged 59 pull requests. You can check the full list of changes
 [here](https://github.com/boa-dev/boa/blob/v0.16/CHANGELOG.md), and the full information on conformance
-[here](https://boa-dev.github.io/boa/test262/).
+[here](/conformance).
 
 <!--truncate-->
 

--- a/blog/2022-10-24-boa-usage.md
+++ b/blog/2022-10-24-boa-usage.md
@@ -19,7 +19,7 @@ This is where Boa enters the scene. Boa is a Javascript engine fully written in 
 can be used in places where you need most of the JavaScript language to work, even though, we would
 advise to wait to get all our [known blocker bugs][blocking] solved before using this for critical
 workloads. You can check how conformant we are with the official ECMAScript specification
-[here](https://boa-dev.github.io/boa/test262/).
+[here](/conformance).
 
 And, before going further, we would like to mention that you can contribute to Boa by solving one
 of the [issues][issues] where we need special help, and we now also accept financial contributions

--- a/blog/2023-07-08-boa-release-17.md
+++ b/blog/2023-07-08-boa-release-17.md
@@ -26,7 +26,7 @@ you wish to sponsor Boa, you can do so by donating to our [open collective][coll
 Furthermore, we now have a new domain for Boa, [boajs.dev][boajs].
 
 [changelog]: https://github.com/boa-dev/boa/blob/v0.17/CHANGELOG.md
-[conformance]: https://boajs.dev/boa/test262/
+[conformance]: /conformance
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/blog/2024-03-07-boa-release-18.md
+++ b/blog/2024-03-07-boa-release-18.md
@@ -38,7 +38,7 @@ some code instead.
 
 [changelog]: https://github.com/boa-dev/boa/blob/v0.18/CHANGELOG.md
 [conformance]: /conformance
-[feed]: /blog/rss.xml
+[feed]: https://boajs.dev/blog/rss.xml
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/blog/2024-03-07-boa-release-18.md
+++ b/blog/2024-03-07-boa-release-18.md
@@ -37,8 +37,8 @@ You can also check [easy][easy_issues] or [good first issues][first_issues] if y
 some code instead.
 
 [changelog]: https://github.com/boa-dev/boa/blob/v0.18/CHANGELOG.md
-[conformance]: https://boajs.dev/boa/test262/
-[feed]: https://boajs.dev/blog/rss.xml
+[conformance]: /conformance
+[feed]: /blog/rss.xml
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/blog/2024-07-09-boa-release-19.md
+++ b/blog/2024-07-09-boa-release-19.md
@@ -210,8 +210,7 @@ Once again, big thanks to [all the contributors][contributors] of this release!!
 
 [contributors]: https://github.com/boa-dev/boa/graphs/contributors?from=2024-03-05&to=2024-07-11&type=c
 [changelog]: https://github.com/boa-dev/boa/blob/v0.19/CHANGELOG.md
-[conformance]: https://boajs.dev/boa/test262/
-[feed]: https://boajs.dev/blog/rss.xml
+[conformance]: /conformance
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/blog/2024-12-05-boa-release-020/index.mdx
+++ b/blog/2024-12-05-boa-release-020/index.mdx
@@ -211,7 +211,6 @@ Once again, big thanks to [all the contributors][contributors] of this release!!
 [contributors]: https://github.com/boa-dev/boa/graphs/contributors?from=2024-03-05&to=2024-07-11&type=c
 [changelog]: https://github.com/boa-dev/boa/blob/v0.19/CHANGELOG.md
 [conformance]: /conformance
-[feed]: /blog/rss.xml
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/blog/2024-12-05-boa-release-020/index.mdx
+++ b/blog/2024-12-05-boa-release-020/index.mdx
@@ -210,8 +210,8 @@ Once again, big thanks to [all the contributors][contributors] of this release!!
 
 [contributors]: https://github.com/boa-dev/boa/graphs/contributors?from=2024-03-05&to=2024-07-11&type=c
 [changelog]: https://github.com/boa-dev/boa/blob/v0.19/CHANGELOG.md
-[conformance]: https://boajs.dev/boa/test262/
-[feed]: https://boajs.dev/blog/rss.xml
+[conformance]: /conformance
+[feed]: /blog/rss.xml
 [collective]: https://opencollective.com/boa
 [easy_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3AE-Easy
 [first_issues]: https://github.com/boa-dev/boa/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -26,7 +26,7 @@ const FeatureList: FeatureItem[] = [
     title: "Aims for ECMAScript Conformance",
     Svg: new_logo_yellow,
     description: (
-      <>Boa passes more than 80% of ECMAScripts test262 test suite.</>
+      <>Boa passes more than 90% of ECMAScripts test262 test suite.</>
     ),
   },
   {


### PR DESCRIPTION
Links to the conformance were broken in the blog and others. Also, we now pass more than 90% of the Test262 tests (even on 0.20, we passed around 90%). So I also updated that.