### PR TITLE
Generate ES versions dynamically

### DIFF
--- a/src/components/conformance/ResultsDisplay/components/SuiteDataContainer/cards/TestGrid/index.tsx
+++ b/src/components/conformance/ResultsDisplay/components/SuiteDataContainer/cards/TestGrid/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  SpecEdition,
   TestOutcome,
   TestResult,
   SuiteResult,
@@ -64,12 +63,25 @@ function applyFilter(filter: FilterOption, outcome: TestOutcome): boolean {
   }
 }
 
+function esFlagToEdition(esFlag: string): number {
+  if (!esFlag.startsWith("es")) {
+    throw RangeError("invalid esFlag");
+  }
+
+  const parsedEsFlag = Number(esFlag.substring(2));
+  if (!Number.isInteger(parsedEsFlag)) {
+    throw RangeError("esFlag is not an integer");
+  }
+
+  return parsedEsFlag;
+}
+
 function Grid(props: GridProps): React.ReactNode {
   return (
     <>
       {props.esFlag
         ? props.tests
-            .filter((test) => test.edition <= SpecEdition[props.esFlag])
+            .filter((test) => test.edition <= esFlagToEdition(props.esFlag))
             .filter((test) => applyFilter(props.filterOption, test.result))
             .map((test) => {
               return (

--- a/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
+++ b/src/components/conformance/ResultsDisplay/components/SuiteSelector/index.tsx
@@ -88,17 +88,17 @@ function SuiteStatistics({
     setFilter(filterOption);
   }, [filterOption]);
 
-  let passed =
+  const passed =
     filter == FilterOption.None || filter == FilterOption.Passed
       ? testResults.passed
       : 0;
 
-  let ignored =
+  const ignored =
     filter == FilterOption.None || filter == FilterOption.Ignored
       ? testResults.ignored
       : 0;
 
-  let failed =
+  const failed =
     filter == FilterOption.None || filter == FilterOption.Failed
       ? `${testResults.total - testResults.passed - testResults.ignored} (${testResults.panic}\u26A0)`
       : 0;

--- a/src/components/conformance/ResultsDisplay/index.tsx
+++ b/src/components/conformance/ResultsDisplay/index.tsx
@@ -13,7 +13,7 @@ import {
   createSearchParams,
   mapToResultInfo,
 } from "@site/src/components/conformance/utils";
-import { useHistory, useLocation } from "@docusaurus/router";
+import { useHistory } from "@docusaurus/router";
 
 import styles from "./styles.module.css";
 
@@ -211,6 +211,7 @@ export default function ResultsDisplay(props: ResultsProps): React.ReactNode {
     <div className={styles.resultsDisplay}>
       <ResultNavigation
         state={props.state}
+        editions={currentSuite ? Object.keys(currentSuite.versionedStats) : []}
         sliceNavToIndex={sliceNavToIndex}
         setEcmaScriptFlag={setEcmaScriptFlag}
         setSortOption={setSortOption}

--- a/src/components/conformance/ResultsDisplay/nav.tsx
+++ b/src/components/conformance/ResultsDisplay/nav.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ConformanceState, FilterOption, SpecEdition } from "../types";
+import { ConformanceState, FilterOption } from "../types";
 
 import styles from "./styles.module.css";
 import Link from "@docusaurus/Link";
@@ -8,6 +8,7 @@ import { availableSortingOptions } from "../utils";
 
 type ResultsNavProps = {
   state: ConformanceState;
+  editions: string[];
   sliceNavToIndex: (number) => void;
   setEcmaScriptFlag: (string) => void;
   setSortOption: (string) => void;
@@ -21,6 +22,7 @@ export default function ResultNavigation(
     <div className={styles.resultsNav}>
       <div className={styles.navSection}>
         <EcmaScriptVersionDropdown
+          editions={props.editions}
           setEcmaScriptFlag={props.setEcmaScriptFlag}
           esVersionValue={props.state.ecmaScriptVersion}
         />
@@ -96,6 +98,7 @@ function BreadCrumbItem(props: BreadCrumbItemProps): React.ReactNode {
 
 type DropDownProps = {
   esVersionValue: string;
+  editions: string[];
   setEcmaScriptFlag: (string) => void;
 };
 
@@ -122,15 +125,13 @@ function EcmaScriptVersionDropdown(props: DropDownProps): React.ReactNode {
       </Heading>
       <select value={dropdownValue} onChange={handleVersionSelection}>
         <option value={""}>All</option>
-        {Object.keys(SpecEdition)
-          .filter((v) => isNaN(Number(v)))
-          .map((key) => {
-            return (
-              <option key={key} value={key}>
-                {key}
-              </option>
-            );
-          })}
+        {props.editions.map((edition) => {
+          return (
+            <option key={edition} value={edition}>
+              {edition}
+            </option>
+          );
+        })}
       </select>
     </div>
   );

--- a/src/components/conformance/types.ts
+++ b/src/components/conformance/types.ts
@@ -54,15 +54,7 @@ export type SuiteResult = {
 };
 
 export type VersionedStats = {
-  es5: TestStats;
-  es6: TestStats;
-  es7: TestStats;
-  es8: TestStats;
-  es9: TestStats;
-  es10: TestStats;
-  es11: TestStats;
-  es12: TestStats;
-  es13: TestStats;
+  [edition: string]: TestStats;
 };
 
 export type TestStats = {
@@ -74,7 +66,7 @@ export type TestStats = {
 
 export type TestResult = {
   name: string;
-  edition: SpecEdition;
+  edition: number;
   strict: boolean;
   result: TestOutcome;
 };
@@ -84,17 +76,4 @@ export enum TestOutcome {
   Ignored,
   Failed,
   Panic,
-}
-
-export enum SpecEdition {
-  es5 = 5,
-  es6,
-  es7,
-  es8,
-  es9,
-  es10,
-  es11,
-  es12,
-  es13,
-  ESNext,
 }

--- a/src/components/conformance/utils.ts
+++ b/src/components/conformance/utils.ts
@@ -3,7 +3,6 @@ import {
   FilterOption,
   ResultInfo,
   SortOption,
-  SpecEdition,
   SuiteResult,
   TestOutcome,
   TestResult,
@@ -12,7 +11,6 @@ import {
   VersionedStats,
   VersionItem,
 } from "@site/src/components/conformance/types";
-import { url } from "node:inspector";
 
 // Take a search param and create a state object
 export function createUrlState(search: string): UrlState {
@@ -251,32 +249,16 @@ export function mapToTestStats(unmappedValue: HttpStatistics): TestStats {
 
 // Interface for the http response of boa_tester's versioned `Statistics`
 interface HttpVersionedStatistics {
-  es5: HttpStatistics;
-  es6: HttpStatistics;
-  es7: HttpStatistics;
-  es8: HttpStatistics;
-  es9: HttpStatistics;
-  es10: HttpStatistics;
-  es11: HttpStatistics;
-  es12: HttpStatistics;
-  es13: HttpStatistics;
+  [edition: string]: HttpStatistics;
 }
 
 // Function for converting an http response of boa_tester's versioned `Statistics` to `VersionedStats`
 export function mapToVersionedStats(
   unmappedValue: HttpVersionedStatistics,
 ): VersionedStats {
-  return {
-    es5: mapToTestStats(unmappedValue.es5),
-    es6: mapToTestStats(unmappedValue.es6),
-    es7: mapToTestStats(unmappedValue.es7),
-    es8: mapToTestStats(unmappedValue.es8),
-    es9: mapToTestStats(unmappedValue.es9),
-    es10: mapToTestStats(unmappedValue.es10),
-    es11: mapToTestStats(unmappedValue.es11),
-    es12: mapToTestStats(unmappedValue.es12),
-    es13: mapToTestStats(unmappedValue.es13),
-  };
+  return Object.fromEntries(
+    Object.entries(unmappedValue).map(([k, v]) => [k, mapToTestStats(v)]),
+  );
 }
 
 // Interface for the http response of boa_tester's `TestResult`
@@ -291,37 +273,10 @@ interface HttpTestResult {
 export function mapToTestResult(unmappedValue: HttpTestResult): TestResult {
   return {
     name: unmappedValue.n,
-    edition: mapToSpecEditionEnum(unmappedValue.v),
+    edition: Number(unmappedValue.v),
     strict: Boolean(unmappedValue.s),
     result: mapToTestOutcomeEnum(unmappedValue.r),
   };
-}
-
-export function mapToSpecEditionEnum(
-  unmappedValue: number | string,
-): SpecEdition {
-  switch (Number(unmappedValue)) {
-    case 5:
-      return SpecEdition.es5;
-    case 6:
-      return SpecEdition.es6;
-    case 7:
-      return SpecEdition.es7;
-    case 8:
-      return SpecEdition.es8;
-    case 9:
-      return SpecEdition.es9;
-    case 10:
-      return SpecEdition.es10;
-    case 11:
-      return SpecEdition.es11;
-    case 12:
-      return SpecEdition.es12;
-    case 13:
-      return SpecEdition.es13;
-    default:
-      return SpecEdition.ESNext;
-  }
 }
 
 export function mapToTestOutcomeEnum(unmappedValue: string): TestOutcome {


### PR DESCRIPTION
This removes all enums related to ES versioning, opting for dynamically generating those based off of the conformance data.